### PR TITLE
replaced balance instead of budget in frontend

### DIFF
--- a/components/GroupLink.js
+++ b/components/GroupLink.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router';
 import Currency from './Currency';
 import Icon from './Icon';
 
-const GroupLink = ({id, name, budget}) => {
+const GroupLink = ({id, name, balance}) => {
   const url = `/groups/${id}/transactions/`;
 
   return (
@@ -14,7 +14,7 @@ const GroupLink = ({id, name, budget}) => {
             {name}
           </span>
           <span className='Well-right'>
-            <Currency value={budget} /> <Icon type='right' />
+            <Currency value={balance} /> <Icon type='right' />
           </span>
         </div>
       </Link>
@@ -24,7 +24,7 @@ const GroupLink = ({id, name, budget}) => {
 
 GroupLink.propTypes = {
   id: PropTypes.number.isRequired,
-  budget: PropTypes.number.isRequired,
+  balance: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired
 };
 

--- a/components/GroupTitle.js
+++ b/components/GroupTitle.js
@@ -5,10 +5,10 @@ export default ({group}) => {
   return (
     <div className='Well'>
       <span className='Well-primary'>
-        Available budget
+        Current balance
       </span>
       <span className='Well-right'>
-        <Currency value={group.budget} />
+        <Currency value={group.balance} />
       </span>
     </div>
   );

--- a/validators/transaction.js
+++ b/validators/transaction.js
@@ -11,7 +11,7 @@ const schema = Joi.object().keys({
     .label('Photo'),
   description: Joi.string().required()
     .label('Title'),
-  amount: Joi.number().precision(2).greater(0).required()
+  amount: Joi.number().precision(2).required()
     .label('Amount'),
   createdAt: Joi.date().max(dates().tomorrow).required()
     .raw() // doesn't convert date into Date object


### PR DESCRIPTION
This is the frontend part of https://github.com/OpenCollective/opencollective-api/pull/32 

I have replaced ```
-        Available budget
-        Current balance```

and added the balance in the frontend. 

Question

If the user wants to enter an expense, he/she needs to enter a negative amount in the input. How do we want to handle the UX for that? The sign is what determines if the transaction is an expense (<0) or a donation (>0).

@xdamman @neilk  
